### PR TITLE
Calculate size of INPUT instead of hard coding value

### DIFF
--- a/Jiggler.cs
+++ b/Jiggler.cs
@@ -40,7 +40,7 @@ namespace ArkaneSystems.MouseJiggle
             inp.time = 0;
             inp.dwExtraInfo = (IntPtr) 0;
 
-            if (SendInput (1, ref inp, 28) != 1)
+            if (SendInput (1, ref inp, Marshal.SizeOf(inp)) != 1)
                 throw new Win32Exception ();
         }
     }

--- a/Jiggler.cs
+++ b/Jiggler.cs
@@ -1,12 +1,12 @@
 #region header
 
 // MouseJiggle - Jiggler.cs
-// 
+//
 // Alistair J. R. Young
 // Arkane Systems
-// 
+//
 // Copyright Arkane Systems 2012-2013.  All rights reserved.
-// 
+//
 // Created: 2014-04-24 8:08 AM
 
 #endregion
@@ -29,16 +29,18 @@ namespace ArkaneSystems.MouseJiggle
         [DllImport ("user32.dll", SetLastError = true)]
         private static extern uint SendInput (uint nInputs, ref INPUT pInputs, int cbSize);
 
-        public static void Jiggle (int dx, int dy)
+        public static void Jiggle(int dx, int dy)
         {
-            var inp = new INPUT ();
-            inp.TYPE = Jiggler.INPUT_MOUSE;
-            inp.dx = dx;
-            inp.dy = dy;
-            inp.mouseData = 0;
-            inp.dwFlags = Jiggler.MOUSEEVENTF_MOVE;
-            inp.time = 0;
-            inp.dwExtraInfo = (IntPtr) 0;
+            var inp = new INPUT
+            {
+                TYPE = Jiggler.INPUT_MOUSE,
+                dx = dx,
+                dy = dy,
+                mouseData = 0,
+                dwFlags = Jiggler.MOUSEEVENTF_MOVE,
+                time = 0,
+                dwExtraInfo = (IntPtr) 0
+            };
 
             if (SendInput (1, ref inp, Marshal.SizeOf(inp)) != 1)
                 throw new Win32Exception ();

--- a/Jiggler.cs
+++ b/Jiggler.cs
@@ -1,12 +1,12 @@
 #region header
 
 // MouseJiggle - Jiggler.cs
-//
+// 
 // Alistair J. R. Young
 // Arkane Systems
-//
+// 
 // Copyright Arkane Systems 2012-2013.  All rights reserved.
-//
+// 
 // Created: 2014-04-24 8:08 AM
 
 #endregion
@@ -29,7 +29,7 @@ namespace ArkaneSystems.MouseJiggle
         [DllImport ("user32.dll", SetLastError = true)]
         private static extern uint SendInput (uint nInputs, ref INPUT pInputs, int cbSize);
 
-        public static void Jiggle(int dx, int dy)
+        public static void Jiggle (int dx, int dy)
         {
             var inp = new INPUT
             {
@@ -42,7 +42,7 @@ namespace ArkaneSystems.MouseJiggle
                 dwExtraInfo = (IntPtr) 0
             };
 
-            if (SendInput (1, ref inp, Marshal.SizeOf(inp)) != 1)
+            if (SendInput (1, ref inp, Marshal.SizeOf (inp)) != 1)
                 throw new Win32Exception ();
         }
     }


### PR DESCRIPTION
No functional change, but it might be better to calculate the size instead of using a hard coded value. This works now that you moved to .NET v4.6.1.

Tested on Windows 10, built with VS 2017.